### PR TITLE
Revert to manual repo name given that cloud build gets the repo with …

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,4 +9,4 @@ steps:
 
 timeout: 1200s
 
-images: ["gcr.io/$PROJECT_ID/$REPO_NAME@sha256:$COMMIT_SHA"]
+images: ["gcr.io/$PROJECT_ID/yoda-ner-api@sha256:$COMMIT_SHA"]


### PR DESCRIPTION
…uppercase and generates image path lowercase. This produces a mismatch and build fails