### PR TITLE
Revert to manual repo name given that cloud build gets the repo with …

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,4 +12,4 @@ steps:
 images: ["${_IMAGE_NAME}"]
 
 substitutions:
-  _IMAGE_NAME: gcr.io/$PROJECT_ID/$REPO_NAME@sha256:$COMMIT_SHA
+  _IMAGE_NAME: "gcr.io/$PROJECT_ID/$REPO_NAME@sha256:$COMMIT_SHA"


### PR DESCRIPTION
…uppercase and generates image path lowercase. This produces a mismatch and build fails