### PR TITLE
Revert to manual repo name given that cloud build gets the repo with …

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
       - --network=host
       - --pull
       - -t
-      - gcr.io/$PROJECT_ID/$REPO_NAME@sha256:$COMMIT_SHA
+      - gcr.io/$PROJECT_ID/$REPO_NAME:latest
       - .
 
-images: ["gcr.io/$PROJECT_ID/$REPO_NAME@sha256:$COMMIT_SHA"]
+images: ["gcr.io/$PROJECT_ID/$REPO_NAME:latest"]


### PR DESCRIPTION
…uppercase and generates image path lowercase. This produces a mismatch and build fails